### PR TITLE
Update ban.js

### DIFF
--- a/commands/moderation/ban.js
+++ b/commands/moderation/ban.js
@@ -47,6 +47,6 @@ module.exports = {
     message.channel.send(embed)
     
     //BAN THE MEMBER
-    target.ban(args[1]);
+    target.ban(target, { reason: args[1] });
   }
 };


### PR DESCRIPTION
Discord.js will return "DICT_TYPE_CONVERT: Only dictionaries may be used in a DictType" with the previous version